### PR TITLE
Add `--experimental-vm-modules` to support ESM bundling

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -19,6 +19,7 @@ if (process.env.GITHUB_TOKEN) {
 
 const configFlags = [
   "--experimental-enable-pointer-compression",
+  "--experimental-vm-modules",
   "--without-inspector",
   "--without-node-snapshot",
   "--without-dtrace",


### PR DESCRIPTION
Hey! I don't really see much movement on the main repo and though we might be able to collaborate.

I'm trying to get pkg to bundle ESM code and I need this flag built into the binaries. Is there anything else I have to do to get this merged?